### PR TITLE
Escape curly braces to prevent Angular XSS

### DIFF
--- a/download.coffee
+++ b/download.coffee
@@ -9,6 +9,8 @@ sanitizeOpts =
 	allowedTags: [ 'b', 'strong', 'a', 'code' ],
 	allowedAttributes:
 		'a': [ 'href', "class" ]
+	textFilter: (text) ->
+		text.replace(/\{\{/, '&#123;&#123;').replace(/\}\}/, '&#125;&#125;')
 
 onesky.string.output platformId:"25049", (err, r)->
 	langs = Object.keys(r.translation['en-US.json'])


### PR DESCRIPTION
To prevent Angular's greedy evaluation of `{{`/`}}`, curly braces are escaped with their HTML entity alternatives.

I'm not really sure what the best way to test this is?