### PR TITLE
Extract language code from hyphenated hostnames

### DIFF
--- a/app/coffee/translations.coffee
+++ b/app/coffee/translations.coffee
@@ -22,9 +22,8 @@ module.exports =
 			host = req.headers.host
 			if !host?
 				return next()
-			subdomain = host.slice(0, host.indexOf("."))
-			if !subdomain?
-				return next()
+                              parts = host.split(/[.-]/)
+			subdomain = parts[0]
 			lang = options?.subdomainLang?[subdomain]?.lngCode
 			if req.originalUrl.indexOf("setLng") == -1 and lang?
 				req.i18n.setLng lang

--- a/app/coffee/translations.coffee
+++ b/app/coffee/translations.coffee
@@ -22,7 +22,7 @@ module.exports =
 			host = req.headers.host
 			if !host?
 				return next()
-                              parts = host.split(/[.-]/)
+			parts = host.split(/[.-]/)
 			subdomain = parts[0]
 			lang = options?.subdomainLang?[subdomain]?.lngCode
 			if req.originalUrl.indexOf("setLng") == -1 and lang?


### PR DESCRIPTION
Previously e.g. `fr.sharelatex.staging` would be split on the period to get the language code `fr`.

Now, split on period or hyphen, so that the language code can be extracted from `fr-staging-google.sharelatex.com`.

Related to Issue: https://github.com/sharelatex/overleaf-google-ops/issues/161